### PR TITLE
Phrasing change

### DIFF
--- a/server/src/classes/generic/damageReports/functions/internalCall.js
+++ b/server/src/classes/generic/damageReports/functions/internalCall.js
@@ -18,8 +18,8 @@ export default (
     )} protocol on the ${displayName} system.`,
     `Ensure there is no residual power flow in the ${displayName} system capacitors.`
   ];
-  return `${preamble || `A call should be made to the system's room.`}
-Ask the ${stationName} officer to make the following internal call:
+  return `${preamble || `A message should be sent to the system's room.`}
+Ask the ${stationName} officer to send the following internal message:
 
 Room: ${room || location}
 Message: ${message || randomFromList(messageList)}


### PR DESCRIPTION
To allow for use in settings that can't use a telephone system to make internal calls, I just re-worded a few things.

## Description
Instead of saying "make an internal call" it says "send an internal message"

## Related Issue
Internal Comm w/out phone

## Screenshots (if appropriate):

- [x] I submitted a pull request or created an issue for documenting this feature on the [Thorium Docs](https://github.com/Thorium-Sim/thorium-docs) repo.
https://github.com/Thorium-Sim/thorium/issues/2018#issue-425796625